### PR TITLE
feat(docs): add tooltips to floating toolbar and replay button

### DIFF
--- a/app/components/docs/DocsCommandMenu.vue
+++ b/app/components/docs/DocsCommandMenu.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
   import { docsNav } from '~/config/docs';
+  import Tooltip from '~/components/ui/tooltip/Tooltip.vue';
+  import TooltipContent from '~/components/ui/tooltip/TooltipContent.vue';
+  import TooltipTrigger from '~/components/ui/tooltip/TooltipTrigger.vue';
 
   const props = defineProps<{
     /** Compact icon-only trigger (for the floating toolbar). */
@@ -66,14 +69,18 @@
 
 <template>
   <!-- Compact icon-only trigger (floating toolbar on component pages) -->
-  <button
-    v-if="props.compact"
-    class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground"
-    aria-label="Search components (⌘K)"
-    @click="isOpen = true"
-  >
-    <Icon name="lucide:search" class="size-4" />
-  </button>
+  <Tooltip v-if="props.compact">
+    <TooltipTrigger as-child>
+      <button
+        class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground"
+        aria-label="Search components (⌘K)"
+        @click="isOpen = true"
+      >
+        <Icon name="lucide:search" class="size-4" />
+      </button>
+    </TooltipTrigger>
+    <TooltipContent>Search (⌘K)</TooltipContent>
+  </Tooltip>
 
   <!-- Full search box (docs header) -->
   <button

--- a/app/components/docs/DocsFloatingToolbar.vue
+++ b/app/components/docs/DocsFloatingToolbar.vue
@@ -5,6 +5,9 @@
   import SheetDescription from '~/components/ui/sheet/SheetDescription.vue';
   import SheetTitle from '~/components/ui/sheet/SheetTitle.vue';
   import SheetTrigger from '~/components/ui/sheet/SheetTrigger.vue';
+  import Tooltip from '~/components/ui/tooltip/Tooltip.vue';
+  import TooltipContent from '~/components/ui/tooltip/TooltipContent.vue';
+  import TooltipTrigger from '~/components/ui/tooltip/TooltipTrigger.vue';
 
   const colorMode = useColorMode();
   const route = useRoute();
@@ -46,14 +49,19 @@
 
     <!-- Sidebar trigger (Sheet) -->
     <Sheet v-model:open="sidebarOpen">
-      <SheetTrigger as-child>
-        <button
-          class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground"
-          aria-label="Toggle navigation"
-        >
-          <Icon name="lucide:panel-left" class="size-4" />
-        </button>
-      </SheetTrigger>
+      <Tooltip>
+        <TooltipTrigger as-child>
+          <SheetTrigger as-child>
+            <button
+              class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground"
+              aria-label="Toggle navigation"
+            >
+              <Icon name="lucide:panel-left" class="size-4" />
+            </button>
+          </SheetTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Navigation</TooltipContent>
+      </Tooltip>
       <SheetContent side="left" class="w-72 p-0">
         <SheetTitle class="sr-only">Navigation</SheetTitle>
         <SheetDescription class="sr-only">
@@ -76,46 +84,66 @@
     </Sheet>
 
     <!-- GitHub link -->
-    <a
-      href="https://github.com/vinayakkulkarni/nxui"
-      target="_blank"
-      rel="noopener noreferrer"
-      class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground"
-    >
-      <Icon name="simple-icons:github" class="size-4" />
-      <span class="sr-only">GitHub</span>
-    </a>
+    <Tooltip>
+      <TooltipTrigger as-child>
+        <a
+          href="https://github.com/vinayakkulkarni/nxui"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground"
+        >
+          <Icon name="simple-icons:github" class="size-4" />
+          <span class="sr-only">GitHub</span>
+        </a>
+      </TooltipTrigger>
+      <TooltipContent>GitHub</TooltipContent>
+    </Tooltip>
 
     <!-- Dark mode toggle -->
-    <button
-      class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground"
-      aria-label="Toggle theme"
-      @click="toggleColorMode"
-    >
-      <ClientOnly>
-        <Icon
-          :name="colorMode.value === 'dark' ? 'lucide:sun' : 'lucide:moon'"
-          class="size-4"
-        />
-        <template #fallback>
-          <Icon name="lucide:moon" class="size-4" />
-        </template>
-      </ClientOnly>
-    </button>
+    <Tooltip>
+      <TooltipTrigger as-child>
+        <button
+          class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground"
+          aria-label="Toggle theme"
+          @click="toggleColorMode"
+        >
+          <ClientOnly>
+            <Icon
+              :name="colorMode.value === 'dark' ? 'lucide:sun' : 'lucide:moon'"
+              class="size-4"
+            />
+            <template #fallback>
+              <Icon name="lucide:moon" class="size-4" />
+            </template>
+          </ClientOnly>
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <ClientOnly>
+          {{ colorMode.value === 'dark' ? 'Light mode' : 'Dark mode' }}
+          <template #fallback>Dark mode</template>
+        </ClientOnly>
+      </TooltipContent>
+    </Tooltip>
 
     <!-- FPS meter toggle -->
-    <button
-      class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 backdrop-blur-sm transition-colors"
-      :class="
-        showFps
-          ? 'text-foreground'
-          : 'text-muted-foreground hover:text-foreground'
-      "
-      :aria-label="showFps ? 'Hide FPS meter' : 'Show FPS meter'"
-      :aria-pressed="showFps"
-      @click="toggleFps"
-    >
-      <Icon name="lucide:gauge" class="size-4" />
-    </button>
+    <Tooltip>
+      <TooltipTrigger as-child>
+        <button
+          class="pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 backdrop-blur-sm transition-colors"
+          :class="
+            showFps
+              ? 'text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          "
+          :aria-label="showFps ? 'Hide FPS meter' : 'Show FPS meter'"
+          :aria-pressed="showFps"
+          @click="toggleFps"
+        >
+          <Icon name="lucide:gauge" class="size-4" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{{ showFps ? 'Hide FPS' : 'Show FPS' }}</TooltipContent>
+    </Tooltip>
   </div>
 </template>

--- a/app/components/docs/DocsSourceCode.vue
+++ b/app/components/docs/DocsSourceCode.vue
@@ -4,6 +4,9 @@
   import SheetDescription from '~/components/ui/sheet/SheetDescription.vue';
   import SheetTitle from '~/components/ui/sheet/SheetTitle.vue';
   import SheetTrigger from '~/components/ui/sheet/SheetTrigger.vue';
+  import Tooltip from '~/components/ui/tooltip/Tooltip.vue';
+  import TooltipContent from '~/components/ui/tooltip/TooltipContent.vue';
+  import TooltipTrigger from '~/components/ui/tooltip/TooltipTrigger.vue';
   import type { RegistryItem } from '~/types/mcp';
 
   const props = defineProps<{
@@ -42,18 +45,23 @@
 
 <template>
   <Sheet v-model:open="open">
-    <SheetTrigger as-child>
-      <button
-        :class="
-          props.mobile
-            ? 'my-1.5 inline-flex size-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
-            : 'pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground'
-        "
-        aria-label="View source code"
-      >
-        <Icon name="lucide:code-xml" class="size-4" />
-      </button>
-    </SheetTrigger>
+    <Tooltip :disabled="props.mobile">
+      <TooltipTrigger as-child>
+        <SheetTrigger as-child>
+          <button
+            :class="
+              props.mobile
+                ? 'my-1.5 inline-flex size-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground'
+                : 'pointer-events-auto inline-flex size-7 items-center justify-center rounded-lg bg-background/80 text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground'
+            "
+            aria-label="View source code"
+          >
+            <Icon name="lucide:code-xml" class="size-4" />
+          </button>
+        </SheetTrigger>
+      </TooltipTrigger>
+      <TooltipContent>View source</TooltipContent>
+    </Tooltip>
     <SheetContent side="left" class="w-full max-w-full p-0 sm:max-w-xl">
       <SheetTitle class="sr-only">Source code</SheetTitle>
       <SheetDescription class="sr-only">

--- a/app/layouts/component.vue
+++ b/app/layouts/component.vue
@@ -1,12 +1,18 @@
+<script setup lang="ts">
+  import TooltipProvider from '~/components/ui/tooltip/TooltipProvider.vue';
+</script>
+
 <template>
-  <div class="relative h-dvh overflow-hidden bg-background">
-    <!-- Subtle gradient overlay for depth -->
-    <div
-      class="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(ellipse_at_top,var(--tw-gradient-stops))] from-violet-500/3 via-transparent to-transparent dark:from-violet-500/6"
-    ></div>
-    <DocsFloatingToolbar />
-    <div class="relative z-10 h-full">
-      <slot></slot>
+  <TooltipProvider>
+    <div class="relative h-dvh overflow-hidden bg-background">
+      <!-- Subtle gradient overlay for depth -->
+      <div
+        class="pointer-events-none fixed inset-0 z-0 bg-[radial-gradient(ellipse_at_top,var(--tw-gradient-stops))] from-violet-500/3 via-transparent to-transparent dark:from-violet-500/6"
+      ></div>
+      <DocsFloatingToolbar />
+      <div class="relative z-10 h-full">
+        <slot></slot>
+      </div>
     </div>
-  </div>
+  </TooltipProvider>
 </template>

--- a/app/pages/docs/[...slug].vue
+++ b/app/pages/docs/[...slug].vue
@@ -3,6 +3,9 @@
   import { defineAsyncComponent } from 'vue';
   import { useClipboard } from '@vueuse/core';
   import { docsNav } from '~/config/docs';
+  import Tooltip from '~/components/ui/tooltip/Tooltip.vue';
+  import TooltipContent from '~/components/ui/tooltip/TooltipContent.vue';
+  import TooltipTrigger from '~/components/ui/tooltip/TooltipTrigger.vue';
 
   definePageMeta({ layout: 'component' });
 
@@ -282,14 +285,18 @@
         <DocsFpsMeter />
 
         <!-- Refresh button for animation demos -->
-        <button
-          v-if="demoRefreshable"
-          class="absolute top-4 right-4 z-10 grid size-9 place-items-center rounded-md border border-border bg-background/50 text-muted-foreground backdrop-blur-sm transition-all hover:bg-background hover:text-foreground"
-          aria-label="Replay animation"
-          @click="replay"
-        >
-          <Icon name="lucide:rotate-ccw" class="size-4" />
-        </button>
+        <Tooltip v-if="demoRefreshable">
+          <TooltipTrigger as-child>
+            <button
+              class="absolute top-4 right-4 z-10 grid size-9 place-items-center rounded-md border border-border bg-background/50 text-muted-foreground backdrop-blur-sm transition-all hover:bg-background hover:text-foreground"
+              aria-label="Replay animation"
+              @click="replay"
+            >
+              <Icon name="lucide:rotate-ccw" class="size-4" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Replay</TooltipContent>
+        </Tooltip>
 
         <!-- Demo component (client-only: WebGL/canvas demos use browser APIs) -->
         <ClientOnly>


### PR DESCRIPTION
## Description

I really love this component set! Though as a first-time user, I found myself unsure what each of the top buttons actually does when opening a component. Adding these small tooltips makes it immediately clear - a nice little quality-of-life touch for anyone exploring **nxui** for the first time.

## Type of change

- [ ] `fix` — bug fix (non-breaking change that fixes an issue)
- [x] `feat` — new component or feature (non-breaking change that adds functionality)
- [ ] `docs` — documentation only
- [ ] `refactor` — code change that neither fixes a bug nor adds a feature
- [ ] `chore` — tooling, dependencies, or build changes
- [ ] Breaking change (fix or feature that would change existing behavior)

## Checklist

- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org) and are signed (`git commit -S`)
- [x] `pnpm run lint` passes with 0 errors and 0 warnings
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` completes successfully
- [ ] For a new component: it is wired into `scripts/build-registry.ts` and `app/config/docs.ts`, has a doc page + demo, and `pnpm run build:registry` succeeds
- [x] I have tested my changes in both light and dark mode
- [x] Types live in `app/types/` (no inline `interface`/`type` in `.vue` files), no `any`

## Screenshots / demo

<img width="556" height="211" alt="Screenshot 2026-07-16 at 21 27 47" src="https://github.com/user-attachments/assets/c7963df1-efc1-44eb-819c-f47d978131f9" />
<img width="556" height="211" alt="Screenshot 2026-07-16 at 21 27 36" src="https://github.com/user-attachments/assets/d200487b-9f2b-4eef-abbb-34ce99b6ce79" />
