### PR TITLE
perf: drop unused prerendered html and fix docs heading order

### DIFF
--- a/app/components/docs/DocsTableOfContents.vue
+++ b/app/components/docs/DocsTableOfContents.vue
@@ -134,9 +134,9 @@
           class="space-y-3 rounded-2xl border border-border/50 bg-muted/20 p-4 backdrop-blur-sm dark:border-white/6 dark:bg-white/2"
         >
           <div class="space-y-1">
-            <h4 class="text-sm font-medium tracking-tight text-foreground">
+            <h3 class="text-sm font-medium tracking-tight text-foreground">
               Need custom components?
-            </h4>
+            </h3>
             <p class="text-xs/relaxed text-muted-foreground">
               Get bespoke UI components &amp; stunning websites tailored for
               your brand.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,6 @@
 import { readdirSync, existsSync } from 'node:fs';
+import { readdir, rm } from 'node:fs/promises';
+import { join, sep } from 'node:path';
 import { docsNav } from './app/config/docs';
 
 const componentCount = readdirSync('registry/new-york', {
@@ -374,6 +376,35 @@ export default defineNuxtConfig({
   // rate-limits itself, so a genuinely missing chunk cannot reload-loop.
   experimental: {
     emitRouteChunkError: 'automatic-immediate',
+  },
+
+  // Prerendering runs for the crawl, not for the HTML: crawlLinks discovers
+  // every docs route so their _payload.json (client-side navigation) and the
+  // sitemap are generated. The HTML itself is never served — run_worker_first
+  // sends every /docs request to the worker, which renders on demand (each
+  // response carries a fresh CSP nonce). Deleting it after the crawl keeps the
+  // payloads and sitemap while dropping ~15 MB from every asset upload. This
+  // only holds on Workers; under Pages the static HTML *was* the page.
+  hooks: {
+    'nitro:init': (nitro) => {
+      nitro.hooks.hook('prerender:done', async () => {
+        const publicDir = nitro.options.output.publicDir;
+        const entries = await readdir(publicDir, { recursive: true });
+        const unusedHtml = entries.filter(
+          (entry) =>
+            entry.endsWith('.html') &&
+            (entry === 'docs.html' || entry.startsWith(`docs${sep}`)),
+        );
+        await Promise.all(
+          unusedHtml.map((entry) =>
+            rm(join(publicDir, entry), { force: true }),
+          ),
+        );
+        nitro.logger.info(
+          `Removed ${unusedHtml.length} worker-rendered HTML files from the asset upload.`,
+        );
+      });
+    },
   },
 
   compatibilityDate: '2025-07-18',


### PR DESCRIPTION
Two changes, plus measured findings on the remaining PageSpeed gap.

## 1. Stop shipping prerendered HTML the worker never serves

`nitro.prerender` runs for the **crawl**, not the HTML: `crawlLinks` walks every docs route so each `_payload.json` (client-side navigation) and the sitemap get generated. The `.html` written alongside them is dead weight — `assets.run_worker_first` covers `/docs` and `/docs/*`, so those documents are always produced by the worker.

Verified rather than assumed: two requests to the same docs URL return **different CSP nonces**, which is only possible if the worker rendered both.

```
Before: 237 HTML files, .output/public/docs = 15 MB
After:    1 HTML file  (index.html), .output/public/docs = 2.7 MB
          236 _payload.json intact · sitemap.xml intact (22,956 bytes)
```

A `prerender:done` hook deletes them after the crawl finishes, so nothing the crawl produces is lost. Confirmed against a real `wrangler dev` on the built output — with zero prerendered HTML present:

| Route | Status | Rendered |
|---|---|---|
| `/docs` | 200 | `<h1>Introduction</h1>` |
| `/docs/components/liquid-glass-carousel` | 200 | `<h1>Liquid Glass Carousel</h1>` |
| `/docs/text-animations/ascii-text` | 200 | real page |
| `/docs/components/liquid-glass-carousel/_payload.json` | 200 | — |
| `/sitemap.xml` | 200 | — |

This is a Workers-only property. Under Pages the static HTML *was* the page, which is why the config still carried it.

## 2. Fix the docs heading order (accessibility)

The table-of-contents CTA card opened an `<h4>` immediately after the page's `<h2>` sections — a skipped level, failing Lighthouse's `heading-order` audit (weight 3). Live `/docs` went `h1 → h2 → h2 → h2 → h2 → h4`; it is now `h1 → h2… → h3`.

## Gates

`lint` 0/0 · `format:check` clean · **doctor 100/100, 0 findings** · production build green · registry 238/0.

---

## On 100/100 PageSpeed — measured, not guessed

The public PSI API is rate-limited right now, so I ran Lighthouse 13.4.1 locally against production (desktop preset, identical config) and, to isolate causes, ran the same page twice — once normally, once with Cloudflare's bot-management script blocked:

| | perf | a11y | best-practices | SEO | TBT | CLS |
|---|---|---|---|---|---|---|
| production as-is | 76–90 | 98 | **81** | 100 | 320 ms | 0.005 |
| same page, `cdn-cgi/challenge-platform` blocked | 88–92 | 98 | **96** | 100 | 170 ms | 0 |

Reproduced across runs. The findings:

- **All 3 `deprecations` warnings come from `/cdn-cgi/challenge-platform/scripts/jsd/main.js`** — Cloudflare's own bot-detection script, injected at the edge (it is not in our HTML). Shared Storage API, `StorageType.persistent`, Protected Audience API. That single audit is the **entire** best-practices deficit: blocking it takes 81 → 96, and nothing in this repo can fix it.
- **TBT is dominated by the same script** — 320 ms → 170 ms with it blocked; it alone contributes ~249 ms of main-thread scripting.
- **`bf-cache` failure is `"Internal error." / "Not actionable"`** — Lighthouse's own words, weight 0.
- The a11y `heading-order` failure is fixed in this PR (98 → expected 100).

So the remaining points are a **zone-configuration** matter, not a code one: reduce Bot Fight Mode / JS Detections for the docs hostname (Security → Bots), which stops the script being injected. I have not touched zone security settings in this PR — that is a deliberate call for you, since it trades a bot-mitigation layer for the score, and the MCP token I have lacks the permission anyway (`9109: Unauthorized`).

Happy to make that change if you want it — say the word and I will, or you can flip it in the dashboard and I will re-measure.
